### PR TITLE
Engine cleanup

### DIFF
--- a/lib/decryption_engine.rb
+++ b/lib/decryption_engine.rb
@@ -9,23 +9,25 @@ class DecryptionEngine
     @decryption = decrypt(message)
   end
 
-  def offset(date, key_array)
-    offsets = date.to_i.abs2.to_s
-    offset_index = -4
-    key_array.map do |key|
-      key_offset = offsets[offset_index].to_i
-      key_int = key.to_i
-      offset_index += 1
-      (key_int += key_offset).to_s
+  def offset_keys
+    generate_keys(key).map.with_index do |key, index|
+      key_offset = generate_offsets(@date)[index]
+      key += key_offset
     end
+  end
+
+  def generate_offsets(date)
+    offsets = date.to_i.abs2.to_s
+    last_4 = offsets.split("").last(4)
+    last_4.map(&:to_i)
   end
 
   def generate_keys(key)
     key_array = []
-    key_array << key[0..1]
-    key_array << key[1..2]
-    key_array << key[2..3]
-    key_array << key[3..4]
+    key_array << key[0..1].to_i
+    key_array << key[1..2].to_i
+    key_array << key[2..3].to_i
+    key_array << key[3..4].to_i
   end
 
   private
@@ -35,14 +37,11 @@ class DecryptionEngine
   end
 
   def decrypt(message)
-    offset_keys = offset(date, generate_keys(key))
-    decrypted_message = ""
-    @message.split("").each_with_index do |char, index|
+    @message.split("").map.with_index do |char, index|
       alphabet = rotated_alphabet(offset_keys[index % 4])
       alpha_index = @alphabet.find_index(char)
-      decrypted_message += alphabet[alpha_index]
-    end
-    decrypted_message
+      alphabet[alpha_index]
+    end.join
   end
 
 end

--- a/lib/encryption_engine.rb
+++ b/lib/encryption_engine.rb
@@ -13,9 +13,8 @@ class EncryptionEngine
     offset_index = -4
     generate_keys(key).map do |key|
       key_offset = generate_offsets(@date)[offset_index].to_i
-      key_int = key.to_i
       offset_index += 1
-      key_int += key_offset
+      key += key_offset
     end
   end
 

--- a/lib/encryption_engine.rb
+++ b/lib/encryption_engine.rb
@@ -10,10 +10,8 @@ class EncryptionEngine
   end
 
   def offset_keys
-    offset_index = -4
-    generate_keys(key).map do |key|
-      key_offset = generate_offsets(@date)[offset_index].to_i
-      offset_index += 1
+    generate_keys(key).map.with_index do |key, index|
+      key_offset = generate_offsets(@date)[index]
       key += key_offset
     end
   end
@@ -39,7 +37,6 @@ class EncryptionEngine
   end
 
   def encrypt(message)
-    # offset_keys = offset(date, generate_keys(key))
     encrypted_message = ""
     @message.split("").each_with_index do |char, index|
       alphabet = rotated_alphabet(offset_keys[index % 4])

--- a/lib/encryption_engine.rb
+++ b/lib/encryption_engine.rb
@@ -15,7 +15,7 @@ class EncryptionEngine
       key_offset = generate_offsets(@date)[offset_index].to_i
       key_int = key.to_i
       offset_index += 1
-      (key_int += key_offset).to_s
+      key_int += key_offset
     end
   end
 
@@ -27,10 +27,10 @@ class EncryptionEngine
 
   def generate_keys(key)
     key_array = []
-    key_array << key[0..1]
-    key_array << key[1..2]
-    key_array << key[2..3]
-    key_array << key[3..4]
+    key_array << key[0..1].to_i
+    key_array << key[1..2].to_i
+    key_array << key[2..3].to_i
+    key_array << key[3..4].to_i
   end
 
   private

--- a/lib/encryption_engine.rb
+++ b/lib/encryption_engine.rb
@@ -9,15 +9,20 @@ class EncryptionEngine
     @encryption = encrypt(message)
   end
 
-  def offset(date, key_array)
-    offsets = date.to_i.abs2.to_s
+  def offset_keys
     offset_index = -4
-    key_array.map do |key|
-      key_offset = offsets[offset_index].to_i
+    generate_keys(key).map do |key|
+      key_offset = generate_offsets(@date)[offset_index].to_i
       key_int = key.to_i
       offset_index += 1
       (key_int += key_offset).to_s
     end
+  end
+
+  def generate_offsets(date)
+    offsets = date.to_i.abs2.to_s
+    last_4 = offsets.split("").last(4)
+    last_4.map(&:to_i)
   end
 
   def generate_keys(key)
@@ -35,7 +40,7 @@ class EncryptionEngine
   end
 
   def encrypt(message)
-    offset_keys = offset(date, generate_keys(key))
+    # offset_keys = offset(date, generate_keys(key))
     encrypted_message = ""
     @message.split("").each_with_index do |char, index|
       alphabet = rotated_alphabet(offset_keys[index % 4])

--- a/lib/encryption_engine.rb
+++ b/lib/encryption_engine.rb
@@ -37,13 +37,11 @@ class EncryptionEngine
   end
 
   def encrypt(message)
-    encrypted_message = ""
-    @message.split("").each_with_index do |char, index|
+    @message.split("").map.with_index do |char, index|
       alphabet = rotated_alphabet(offset_keys[index % 4])
       alpha_index = @alphabet.find_index(char)
-      encrypted_message += alphabet[alpha_index]
-    end
-    encrypted_message
+      char = alphabet[alpha_index]
+    end.join
   end
 
 end

--- a/lib/encryption_engine.rb
+++ b/lib/encryption_engine.rb
@@ -40,7 +40,7 @@ class EncryptionEngine
     @message.split("").map.with_index do |char, index|
       alphabet = rotated_alphabet(offset_keys[index % 4])
       alpha_index = @alphabet.find_index(char)
-      char = alphabet[alpha_index]
+      alphabet[alpha_index]
     end.join
   end
 

--- a/test/decryption_engine_test.rb
+++ b/test/decryption_engine_test.rb
@@ -10,10 +10,14 @@ class DecryptionEngineTest < Minitest::Test
   end
 
   def test_it_can_generate_keys
-    assert_equal ["12", "23", "34", "45"], @decryption_engine.generate_keys("12345")
+    assert_equal [12, 23, 34, 45], @decryption_engine.generate_keys("12345")
+  end
+
+  def test_it_can_generate_offsets
+    assert_equal [9, 0, 2, 5], @decryption_engine.generate_offsets("012345")
   end
 
   def test_it_can_generate_offset_keys
-    assert_equal ["21", "23", "36", "50"], @decryption_engine.offset("012345", ["12", "23", "34", "45"])
+    assert_equal [3, 27, 73, 20], @decryption_engine.offset_keys
   end
 end

--- a/test/encryption_engine_test.rb
+++ b/test/encryption_engine_test.rb
@@ -13,7 +13,11 @@ class EncryptionEngineTest < Minitest::Test
     assert_equal ["12", "23", "34", "45"], @encryption_engine.generate_keys("12345")
   end
 
+  def test_it_can_generate_offsets
+    assert_equal [12, 23, 34, 45], @encryption_engine.generate_offsets("012345")
+  end
+
   def test_it_can_generate_offset_keys
-    assert_equal ["21", "23", "36", "50"], @encryption_engine.offset("012345", ["12", "23", "34", "45"])
+    assert_equal [21, 23, 36, 50], @encryption_engine.offset_keys
   end
 end

--- a/test/encryption_engine_test.rb
+++ b/test/encryption_engine_test.rb
@@ -18,6 +18,6 @@ class EncryptionEngineTest < Minitest::Test
   end
 
   def test_it_can_generate_offset_keys
-    assert_equal [3, 27, 73, 21], @encryption_engine.offset_keys
+    assert_equal [3, 27, 73, 20], @encryption_engine.offset_keys
   end
 end

--- a/test/encryption_engine_test.rb
+++ b/test/encryption_engine_test.rb
@@ -10,7 +10,7 @@ class EncryptionEngineTest < Minitest::Test
   end
 
   def test_it_can_generate_keys
-    assert_equal ["12", "23", "34", "45"], @encryption_engine.generate_keys("12345")
+    assert_equal [12, 23, 34, 45], @encryption_engine.generate_keys("12345")
   end
 
   def test_it_can_generate_offsets

--- a/test/encryption_engine_test.rb
+++ b/test/encryption_engine_test.rb
@@ -14,7 +14,7 @@ class EncryptionEngineTest < Minitest::Test
   end
 
   def test_it_can_generate_offsets
-    assert_equal [12, 23, 34, 45], @encryption_engine.generate_offsets("012345")
+    assert_equal [1, 0, 2, 5], @encryption_engine.generate_offsets("012345")
   end
 
   def test_it_can_generate_offset_keys

--- a/test/encryption_engine_test.rb
+++ b/test/encryption_engine_test.rb
@@ -14,10 +14,10 @@ class EncryptionEngineTest < Minitest::Test
   end
 
   def test_it_can_generate_offsets
-    assert_equal [1, 0, 2, 5], @encryption_engine.generate_offsets("012345")
+    assert_equal [9, 0, 2, 5], @encryption_engine.generate_offsets("012345")
   end
 
   def test_it_can_generate_offset_keys
-    assert_equal [21, 23, 36, 50], @encryption_engine.offset_keys
+    assert_equal [3, 27, 73, 21], @encryption_engine.offset_keys
   end
 end


### PR DESCRIPTION
This PR takes the methods from both the Encryption and Decryption engines and refactors them to split into helper methods and use less lines overall. This PR also proves the point that these methods should be in a module, since they are exactly the same codewise.
First step was splitting the #offset method in to two methods that would:
__Generate Offsets out of the date__
Simple helper method to take one argument of a date and perform the squaring math, and then pulling only the last 4 numbers.
__Combining keys and offsets to create Offset Keys__
This method takes no arguments since all data is stored inside the class instance, but calls on both of the generate methods to return a new array of offsetted keys for use in our *crypt methods.

The two generate_methods also changed the expected return values to be integers instead of strings, reducing excessive integer/string swapping. We store the original key and date as strings, so there is no reason to switch them round endlessly when we can just return those for any bookkeeping reasons.

Second change was the *crypt methods using map.with_index and .join instead of storing shifted characters in an empty array. This reduces lines overall, and also uses our offset_keys method instead of storing said keys in another variable.

Next step: Turn these methods into a module and move tests to another file.