### PR TITLE
Downcase messages

### DIFF
--- a/lib/decryption_engine.rb
+++ b/lib/decryption_engine.rb
@@ -8,7 +8,7 @@ class DecryptionEngine
     @key = key
     @date = date
     @alphabet = ("a".."z").to_a << " "
-    @decryption = send(message)
+    @decryption = send(message.downcase)
   end
 
   private

--- a/lib/encryption_engine.rb
+++ b/lib/encryption_engine.rb
@@ -8,7 +8,7 @@ class EncryptionEngine
     @key = key
     @date = date
     @alphabet = ("a".."z").to_a << " "
-    @encryption = send(message)
+    @encryption = send(message.downcase)
   end
 
   private

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -45,6 +45,12 @@ class EnigmaTest < Minitest::Test
     assert_equal expected, @enigma.encrypt("HELLO WORLD", "02715", "040895")
   end
 
+  def test_it_will_downcase_capitalized_messages
+    expected = {encryption: "keder ohulw", key: "02715", date: "040895"}
+
+    assert_equal expected, @enigma.encrypt("HeLlO wOrLD", "02715", "040895")
+  end
+
   def test_it_will_downcase_decrypted_messages
     expected = {decryption: "hello world", key: "02715", date: "040895"}
 

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -38,4 +38,10 @@ class EnigmaTest < Minitest::Test
 
     assert_equal "09729", @enigma.encrypt("hello world")[:key]
   end
+
+  def test_it_will_downcase_messages
+    expected = {encryption: "keder ohulw", key: "02715", date: "040895"}
+
+    assert_equal expected, @enigma.encrypt("HELLO WORLD", "02715", "040895")
+  end
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -39,9 +39,15 @@ class EnigmaTest < Minitest::Test
     assert_equal "09729", @enigma.encrypt("hello world")[:key]
   end
 
-  def test_it_will_downcase_messages
+  def test_it_will_downcase_encrypted_messages
     expected = {encryption: "keder ohulw", key: "02715", date: "040895"}
 
     assert_equal expected, @enigma.encrypt("HELLO WORLD", "02715", "040895")
+  end
+
+  def test_it_will_downcase_decrypted_messages
+    expected = {decryption: "hello world", key: "02715", date: "040895"}
+
+    assert_equal expected, @enigma.decrypt("KEDER OHULW", "02715", "040895")
   end
 end


### PR DESCRIPTION
This PR covers the instances where a message might be given that is in Upcase or Capitalized. When this happens, our default lowercase library would run into issues, so now we just downcase the message before it gets to our #send method.
This ensures that a message is always encrypted/decrypted in all lower case, allowing us to avoid the issue of having a 53 character alphabet. We can cover any casing and also not reveal capitalized proper names or nouns for the enemy to focus on.