### PR TITLE
Foreign characters

### DIFF
--- a/lib/engine_module.rb
+++ b/lib/engine_module.rb
@@ -32,11 +32,8 @@ module EngineModule
 
   def send(message)
     message.split("").map.with_index do |char, index|
-      if @alphabet.include?(char)
+      next char unless @alphabet.include?(char)
         rotate_char(char, index)
-      else
-        char
-      end
     end.join
   end
 end

--- a/lib/engine_module.rb
+++ b/lib/engine_module.rb
@@ -26,9 +26,13 @@ module EngineModule
 
   def send(message)
     message.split("").map.with_index do |char, index|
-      alphabet = rotated_alphabet(offset_keys[index % 4])
-      alpha_index = @alphabet.find_index(char)
-      alphabet[alpha_index]
+      if @alphabet.include?(char)
+        alphabet = rotated_alphabet(offset_keys[index % 4])
+        alpha_index = @alphabet.find_index(char)
+        alphabet[alpha_index]
+      else
+        char
+      end
     end.join
   end
 end

--- a/lib/engine_module.rb
+++ b/lib/engine_module.rb
@@ -24,12 +24,16 @@ module EngineModule
 
   private
 
+  def rotate_char(char, index)
+    alphabet = rotated_alphabet(offset_keys[index % 4])
+    alpha_index = @alphabet.find_index(char)
+    alphabet[alpha_index]
+  end
+
   def send(message)
     message.split("").map.with_index do |char, index|
       if @alphabet.include?(char)
-        alphabet = rotated_alphabet(offset_keys[index % 4])
-        alpha_index = @alphabet.find_index(char)
-        alphabet[alpha_index]
+        rotate_char(char, index)
       else
         char
       end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -56,4 +56,10 @@ class EnigmaTest < Minitest::Test
 
     assert_equal expected, @enigma.decrypt("KEDER OHULW", "02715", "040895")
   end
+
+  def test_it_can_encrypt_a_message_with_bang
+    expected = {encryption: "keder ohulw!", key: "02715", date: "040895"}
+
+    assert_equal expected, @enigma.encrypt("hello world!", "02715", "040895")
+  end
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -62,4 +62,10 @@ class EnigmaTest < Minitest::Test
 
     assert_equal expected, @enigma.encrypt("hello world!", "02715", "040895")
   end
+  # 
+  # def test_it_can_encrypt_a_message_with_a_comma
+  #   expected = {encryption: "keder, ohulw", key: "02715", date: "040895"}
+  #
+  #   assert_equal expected, @enigma.encrypt("hello, world", "02715", "040895")
+  # end
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -68,4 +68,10 @@ class EnigmaTest < Minitest::Test
 
     assert_equal expected, @enigma.encrypt("hello, world", "02715", "040895")
   end
+
+  def test_it_can_decrypt_a_message_with_a_comma
+    expected = {decryption: "hello, world", key: "02715", date: "040895"}
+
+    assert_equal expected, @enigma.decrypt("keder,sprrdx", "02715", "040895")
+  end
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -62,10 +62,10 @@ class EnigmaTest < Minitest::Test
 
     assert_equal expected, @enigma.encrypt("hello world!", "02715", "040895")
   end
-  # 
-  # def test_it_can_encrypt_a_message_with_a_comma
-  #   expected = {encryption: "keder, ohulw", key: "02715", date: "040895"}
-  #
-  #   assert_equal expected, @enigma.encrypt("hello, world", "02715", "040895")
-  # end
+
+  def test_it_can_encrypt_a_message_with_a_comma
+    expected = {encryption: "keder,sprrdx", key: "02715", date: "040895"}
+
+    assert_equal expected, @enigma.encrypt("hello, world", "02715", "040895")
+  end
 end


### PR DESCRIPTION
This PR adds the logic check on the #send method to ensure that when it encounters a foreign character, it will return the foreign character instead of trying to Cipher it.
A foreign character is anything that is not included in our alphabet array, aka numbers, punctuation, etc.
Currently, the main test is covering an exclamation point at the end of the sentence. A foreign character in the middle of a message will completely change the rest of the method, currently. This foreign character still counts as an index spot, and the Enigma will move onto the next shift for the next element as normal.
Will need to check back to see how it should behave.