### PR TITLE
Encrypt decrypt edge cases

### DIFF
--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -56,6 +56,14 @@ class EnigmaTest < Minitest::Test
     assert_equal expected, @enigma.encrypt("hello world")
   end
 
+  def test_it_can_decrypt_a_message_without_a_date
+    expected = {decryption: "hello world", key: "02715", date: "030201"}
+    fake_date = Date.new(2001, 2, 3)
+    Date.stubs(today: fake_date)
+
+    assert_equal expected, @enigma.decrypt("jibaqdmdtpu", "02715")
+  end
+
   def test_it_will_downcase_encrypted_messages
     expected = {encryption: "keder ohulw", key: "02715", date: "040895"}
 

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -39,6 +39,23 @@ class EnigmaTest < Minitest::Test
     assert_equal "09729", @enigma.encrypt("hello world")[:key]
   end
 
+  def test_it_can_encrypt_a_message_without_a_date
+    expected = {encryption: "jibaqdmdtpu", key: "02715", date: "030201"}
+    fake_date = Date.new(2001, 2, 3)
+    Date.stubs(today: fake_date)
+
+    assert_equal expected, @enigma.encrypt("hello world", "02715")
+  end
+
+  def test_it_can_encrypt_a_message_without_a_key_or_date
+    expected = {encryption: "qycoxtnr ev", key: "09729", date: "030201"}
+    srand(2231489724)
+    fake_date = Date.new(2001, 2, 3)
+    Date.stubs(today: fake_date)
+
+    assert_equal expected, @enigma.encrypt("hello world")
+  end
+
   def test_it_will_downcase_encrypted_messages
     expected = {encryption: "keder ohulw", key: "02715", date: "040895"}
 


### PR DESCRIPTION
This PR implements a couple of tests to ensure that the random key and todays date methods work correctly. These should have been implemented prior, but regardless, no code was changed.
Encrypt should create both and use them if only given a message, and Decrypt requires a message and a key, but should create the date. 
Using srand on random_keys and stubs on Date, I was able to create stable tests that always return and perform the same things every time.